### PR TITLE
Fix typo in README.es.md about exercise count

### DIFF
--- a/exercises/10.1-Creating-Your-First-Function/README.es.md
+++ b/exercises/10.1-Creating-Your-First-Function/README.es.md
@@ -16,7 +16,7 @@ tutorial: "https://www.youtube.com/watch?v=ePn8AzCG57Y"
 
 ## 🔎 Importante:
 
-+ Para practicar con más funciones, 4Geeks Academy tiene más de 20 ejercicios que se incrementan en dificultad: [https://github.com/4GeeksAcademy/python-functions-programming-exercises](https://github.com/4GeeksAcademy/python-functions-programming-exercises).
++ Para practicar con más funciones, 4Geeks Academy tiene más ejercicios que se incrementan en dificultad: [https://github.com/4GeeksAcademy/python-functions-programming-exercises](https://github.com/4GeeksAcademy/python-functions-programming-exercises).
 
 ¡Inténtalos, y luego regresa! 😃  
 


### PR DESCRIPTION
Se corrigió un error en el README donde se menciona que se deben realizar más de 20 ejercicios. Sin embargo, al acceder al repositorio enlazado, se observa que solo hay ejercicios numerados del 00 al 09.  Por esta razón, eliminé la cantidad incorrecta de "más de 20 ejercicios" para reflejar con mayor precisión que el repositorio contiene más ejercicios disponibles, sin especificar una cantidad exacta.

Por favor, solicito que revisen y aprueben este cambio para evitar confusiones en futuros usuarios.   Muchas gracias.